### PR TITLE
Fix in Atmosphere.rb for ruby 1.9 case syntax

### DIFF
--- a/lib/yahoo-weather/atmosphere.rb
+++ b/lib/yahoo-weather/atmosphere.rb
@@ -32,9 +32,9 @@ class YahooWeather::Atmosphere
     # map barometric pressure direction to appropriate constant
     @barometer = nil
     case payload['rising'].to_i
-    when 0: @barometer = Barometer::STEADY
-    when 1: @barometer = Barometer::RISING
-    when 2: @barometer = Barometer::FALLING
+    when 0 then @barometer = Barometer::STEADY
+    when 1 then @barometer = Barometer::RISING
+    when 2 then @barometer = Barometer::FALLING
     end
   end
 end


### PR DESCRIPTION
Hi:

I changed this for ruby 1.9 compatibility which should also be compatible with 1.8

Thanks for your work on this.

If you don't want to pull this commit, do you know how I can get this code working in my site. I keep getting a message saying
"Could not find gem 'yahoo-weather (>= 0, runtime)' in git://github.com/AlanMcCann/yahoo-weather.git (at master).
Source does not contain any versions of 'yahoo-weather (>= 0, runtime)'
"

Thanks
Alan
