### PR TITLE
Support for PubDate

### DIFF
--- a/lib/yahoo-weather/atmosphere.rb
+++ b/lib/yahoo-weather/atmosphere.rb
@@ -32,9 +32,9 @@ class YahooWeather::Atmosphere
     # map barometric pressure direction to appropriate constant
     @barometer = nil
     case payload['rising'].to_i
-    when 0: @barometer = Barometer::STEADY
-    when 1: @barometer = Barometer::RISING
-    when 2: @barometer = Barometer::FALLING
+    when 0 then @barometer = Barometer::STEADY
+    when 1 then @barometer = Barometer::RISING
+    when 2 then @barometer = Barometer::FALLING
     end
   end
 end

--- a/lib/yahoo-weather/response.rb
+++ b/lib/yahoo-weather/response.rb
@@ -1,4 +1,3 @@
-# TODO: Add pub date
 # Describes the weather conditions for a particular requested location.
 class YahooWeather::Response
   # a YahooWeather::Astronomy object detailing the sunrise and sunset
@@ -85,6 +84,6 @@ class YahooWeather::Response
     @page_url = item.xpath('link').first.content
     @title = item.xpath('title').first.content
     @description = item.xpath('description').first.content
-    @pubdate = item.xpath('pubdate').first.content
+    @pubdate = item.xpath('pubDate').first.content
   end
 end

--- a/lib/yahoo-weather/response.rb
+++ b/lib/yahoo-weather/response.rb
@@ -1,3 +1,4 @@
+# TODO: Add pub date
 # Describes the weather conditions for a particular requested location.
 class YahooWeather::Response
   # a YahooWeather::Astronomy object detailing the sunrise and sunset
@@ -54,6 +55,9 @@ class YahooWeather::Response
 
   # the prose descriptive title of the weather information.
   attr_reader :title
+  
+  # the date in which the weather data was last updated
+  attr_reader :pubdate
 
   def initialize (request_location, request_url, doc)
     # save off the request params
@@ -81,5 +85,6 @@ class YahooWeather::Response
     @page_url = item.xpath('link').first.content
     @title = item.xpath('title').first.content
     @description = item.xpath('description').first.content
+    @pubdate = item.xpath('pubdate').first.content
   end
 end

--- a/lib/yahoo-weather/response.rb
+++ b/lib/yahoo-weather/response.rb
@@ -84,6 +84,6 @@ class YahooWeather::Response
     @page_url = item.xpath('link').first.content
     @title = item.xpath('title').first.content
     @description = item.xpath('description').first.content
-    @pubdate = item.xpath('pubDate').first.content
+    @pubdate = YahooWeather._parse_time(item.xpath('pubDate').first.content)
   end
 end

--- a/test/test_api.rb
+++ b/test/test_api.rb
@@ -122,6 +122,7 @@ class TestAPI < Test::Unit::TestCase
       assert(response.image.url =~ /yimg\.com/)
       assert_kind_of Numeric, response.latitude
       assert_kind_of Numeric, response.longitude
+      assert_instance_of Time, response.pubdate
       assert(response.page_url =~ /\.html$/)
       assert(response.title && response.title.length > 0)
       assert_not_nil(response.title.index("#{response.location.city}, #{response.location.region}"))

--- a/tomk32-yahoo-weather.gemspec
+++ b/tomk32-yahoo-weather.gemspec
@@ -1,0 +1,19 @@
+Gem::Specification.new do |s|
+  s.name = 'tomk32-yahoo-weather'
+  s.version = '1.2.1'
+  s.summary = 'A Ruby object-oriented interface to the Yahoo! Weather service'
+  s.description = "The yahoo-weather rubygem provides a Ruby object-oriented interface to the Yahoo! Weather service described in detail at: http://developer.yahoo.com/weather"
+
+  s.add_dependency('nokogiri', '>= 1.4.1')
+  s.add_dependency('hoe',   '>= 2.4.0')
+
+  s.rdoc_options << '--exclude' << '.'
+  s.has_rdoc = false
+
+  s.files = Dir['CHANGELOG.rdoc', 'README', 'Manifest.txt', 'Rakefile', 'TODO', 'examples/*', 'lib/**', 'test/**']
+  s.require_path = 'lib'
+
+  s.author = "Walter Korman"
+  s.email = "shaper@fatgoose.com"
+  s.homepage = "http://rubyforge.org/projects/yahoo-weather"
+end

--- a/tomk32-yahoo-weather.gemspec
+++ b/tomk32-yahoo-weather.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name = 'tomk32-yahoo-weather'
+  s.name = 'yahoo-weather'
   s.version = '1.2.1'
   s.summary = 'A Ruby object-oriented interface to the Yahoo! Weather service'
   s.description = "The yahoo-weather rubygem provides a Ruby object-oriented interface to the Yahoo! Weather service described in detail at: http://developer.yahoo.com/weather"
@@ -8,10 +8,10 @@ Gem::Specification.new do |s|
   s.add_dependency('hoe',   '>= 2.4.0')
 
   s.rdoc_options << '--exclude' << '.'
-  s.has_rdoc = false
 
-  s.files = Dir['CHANGELOG.rdoc', 'README', 'Manifest.txt', 'Rakefile', 'TODO', 'examples/*', 'lib/**', 'test/**']
+  s.files = Dir['CHANGELOG.rdoc', 'README', 'Manifest.txt', 'Rakefile', 'TODO', 'examples/*', 'lib/**', 'lib/**/**', 'test/**']
   s.require_path = 'lib'
+  s.test_file = 'test/test_api.rb'
 
   s.author = "Walter Korman"
   s.email = "shaper@fatgoose.com"


### PR DESCRIPTION
Hello:

Thanks so much for creating this gem. I'm really enjoying it so far.

I added support for a pubdate attribute in the response object. Now, you can do something like the following to find out when the forecast was last updated:

`puts YahooWeather::Client.new.lookup_location("48125").pubdate.strftime('%H:%m')`

I also wrote a test for the new attribute, and fixed a bug in the gemspec that stopped the files in `lib/yahoo-weather/**` from being loaded when requested with `require`.
