### PR TITLE
case/when fix

### DIFF
--- a/lib/yahoo-weather/atmosphere.rb
+++ b/lib/yahoo-weather/atmosphere.rb
@@ -32,9 +32,12 @@ class YahooWeather::Atmosphere
     # map barometric pressure direction to appropriate constant
     @barometer = nil
     case payload['rising'].to_i
-    when 0: @barometer = Barometer::STEADY
-    when 1: @barometer = Barometer::RISING
-    when 2: @barometer = Barometer::FALLING
+    when 0
+      @barometer = Barometer::STEADY
+    when 1 
+      @barometer = Barometer::RISING
+    when 2
+      @barometer = Barometer::FALLING
     end
   end
 end


### PR DESCRIPTION
if/case/when doesn't work on ruby 1.9 and a newline has to be used (else it doesn't compile).

Hope it helps
